### PR TITLE
feat(widgets): styles of DocumentSelfieVerification mobile version and DocumentPainter updated

### DIFF
--- a/lib/widgets/custom_paint.dart
+++ b/lib/widgets/custom_paint.dart
@@ -17,6 +17,7 @@ class DocumentPainter extends CustomPainter {
 
     double cornerValue = 50;
 
+    canvas.drawColor(color, BlendMode.srcOver);
     canvas.drawPath(
       Path.combine(
         PathOperation.difference,
@@ -26,11 +27,11 @@ class DocumentPainter extends CustomPainter {
         Path()
           ..addRRect(
             RRect.fromLTRBR(
-              64,
-              32,
-              size.width - 32,
-              size.height - 32,
-              const Radius.circular(10),
+              0,
+              0,
+              size.width,
+              size.height,
+              const Radius.circular(0),
             ),
           )
           ..close(),
@@ -45,7 +46,7 @@ class DocumentPainter extends CustomPainter {
             RRect.fromLTRBR(
               124,
               44,
-              size.width - 96,
+              size.width,
               size.height - 44,
               const Radius.circular(10),
             ),
@@ -55,7 +56,7 @@ class DocumentPainter extends CustomPainter {
             RRect.fromLTRBR(
               124 + 4,
               44 + 4,
-              size.width - (96 + 4),
+              size.width - 4,
               size.height - (44 + 4),
               const Radius.circular(10),
             ),
@@ -70,7 +71,7 @@ class DocumentPainter extends CustomPainter {
             RRect.fromLTRBR(
               124 + cornerValue,
               44,
-              size.width - (96 + cornerValue),
+              size.width - cornerValue,
               size.height - 44,
               const Radius.circular(0),
             ),
@@ -85,7 +86,7 @@ class DocumentPainter extends CustomPainter {
             RRect.fromLTRBR(
               124,
               44 + cornerValue,
-              size.width - 96,
+              size.width,
               size.height - (44 + cornerValue),
               const Radius.circular(0),
             ),

--- a/lib/widgets/mobile.dart
+++ b/lib/widgets/mobile.dart
@@ -41,7 +41,7 @@ class Mobile extends DocumentSelfieVerificationState {
     return SvgPicture.asset(
       imageToRender,
       package: 'document_selfie_verification',
-      width: MediaQuery.of(context).size.width * 0.45,
+      width: MediaQuery.of(context).size.width * 0.5,
     );
   }
 
@@ -114,9 +114,9 @@ class Mobile extends DocumentSelfieVerificationState {
                       ),
                     ),
                     ColoredBox(
-                      color: const Color(0xff28363e),
+                      color: Colors.transparent,
                       child: SizedBox(
-                        width: 100 + marginBottom,
+                        width: width * 0.15,
                         height: height,
                         child: Center(
                           child: Visibility(
@@ -142,7 +142,7 @@ class Mobile extends DocumentSelfieVerificationState {
                 ),
                 Positioned(
                   bottom: 32,
-                  right: 100 + marginBottom + 30,
+                  right: 24,
                   child: CircleAvatar(
                     radius: 22,
                     backgroundColor:
@@ -169,69 +169,56 @@ class Mobile extends DocumentSelfieVerificationState {
                                 return Material(
                                   color: Colors.transparent,
                                   child: Center(
-                                      child: ConstrainedBox(
-                                    constraints: BoxConstraints(
-                                      maxHeight: height,
-                                      maxWidth: width,
-                                    ),
+                                      child: DecoratedBox(
+                                    decoration: BoxDecoration(
+                                        borderRadius: BorderRadius.circular(8),
+                                        color: Colors.black.withOpacity(0.6)),
                                     child: Padding(
-                                      padding: EdgeInsets.only(
-                                          left: 30, right: 100 + marginBottom),
-                                      child: Center(
-                                          child: DecoratedBox(
-                                        decoration: BoxDecoration(
-                                            borderRadius:
-                                                BorderRadius.circular(8),
-                                            color:
-                                                Colors.black.withOpacity(0.6)),
-                                        child: Padding(
-                                          padding: const EdgeInsets.all(16.0),
-                                          child: Column(
+                                      padding: const EdgeInsets.all(16.0),
+                                      child: Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: <Widget>[
+                                            Row(
+                                              mainAxisAlignment:
+                                                  MainAxisAlignment.start,
+                                              crossAxisAlignment:
+                                                  CrossAxisAlignment.start,
                                               mainAxisSize: MainAxisSize.min,
                                               children: <Widget>[
-                                                Row(
-                                                  mainAxisAlignment:
-                                                      MainAxisAlignment.start,
-                                                  crossAxisAlignment:
-                                                      CrossAxisAlignment.start,
-                                                  mainAxisSize:
-                                                      MainAxisSize.min,
-                                                  children: <Widget>[
-                                                    const Icon(
-                                                      Icons.info_outline,
-                                                      color: Colors.white,
-                                                    ),
-                                                    const SizedBox(
-                                                      width: 8,
-                                                    ),
-                                                    Text(
-                                                        'Cara ${widget.side == SideType.frontSide ? 'frontal' : 'posterior'} del\ndocumento',
-                                                        style: const TextStyle(
-                                                            fontSize: 18,
-                                                            fontWeight:
-                                                                FontWeight.w600,
-                                                            color:
-                                                                Colors.white))
-                                                  ],
+                                                const Icon(
+                                                  Icons.info_outline,
+                                                  color: Colors.white,
                                                 ),
                                                 const SizedBox(
-                                                  height: 8,
+                                                  width: 8,
                                                 ),
-                                                const Text(
-                                                    '• Ubica tu documento de identidad\n completo dentro del marco.\n• Usa buena iluminación, evita reflejos\n y texturas en el fondo.\n• Asegúrate que el rostro y los datos\n son legibles.',
-                                                    style: TextStyle(
-                                                        fontSize: 14,
-                                                        color: Colors.white)),
-                                              ]),
-                                        ),
-                                      )),
+                                                Text(
+                                                    'Cara ${widget.side == SideType.frontSide ? 'frontal' : 'posterior'} del\ndocumento',
+                                                    style: const TextStyle(
+                                                        fontSize: 18,
+                                                        fontWeight:
+                                                            FontWeight.w600,
+                                                        color: Colors.white))
+                                              ],
+                                            ),
+                                            const SizedBox(
+                                              height: 8,
+                                            ),
+                                            const Text(
+                                                '• Ubica tu documento de identidad\n completo dentro del marco.\n• Usa buena iluminación, evita reflejos\n y texturas en el fondo.\n• Asegúrate que el rostro y los datos\n son legibles.',
+                                                style: TextStyle(
+                                                    fontSize: 14,
+                                                    color: Colors.white)),
+                                          ]),
                                     ),
                                   )),
                                 );
                               });
 
                           Timer(
-                            const Duration(seconds: 3),
+                            const Duration(seconds: 4),
                             closeInfoModal,
                           );
                         },
@@ -241,10 +228,26 @@ class Mobile extends DocumentSelfieVerificationState {
                 ),
                 Visibility(
                   visible: showID,
-                  child: Positioned(
-                    bottom: 80,
-                    left: width * 0.20,
+                  child: Center(
                     child: loadImage,
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 32),
+                  child: SizedBox(
+                    width: width,
+                    child: Align(
+                      alignment: Alignment.topCenter,
+                      child: Text(
+                        'Cara ${widget.side == SideType.frontSide ? 'frontal' : 'posterior'} del documento',
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w600,
+                          height: 24 / 18,
+                        ),
+                      ),
+                    ),
                   ),
                 ),
                 if (showFocusCircle)


### PR DESCRIPTION
Feat: styles of DocumentSelfieVerification mobile version and DocumentPainter updated [[TYBA-60104]](https://starkmvp.atlassian.net/browse/TYBA-60104)

[Figma](https://www.figma.com/design/el6mkz9P7CXUBJqKU5bU8h/Transversales---InProduction?node-id=852-67432&t=XcvT8IjjIBmpvIhd-4)

<img width="300" alt="image" src="https://github.com/tyba-co/document_selfie_verification/assets/175073213/5777df7d-ef84-4591-ab46-d91b68f74ea6">
<img width="300" alt="image" src="https://github.com/tyba-co/document_selfie_verification/assets/175073213/a767cbc6-1cb5-402a-918f-a06484e58b49">
<img width="300" alt="image" src="https://github.com/tyba-co/document_selfie_verification/assets/175073213/eaf00b6b-b58a-41b9-921a-f86085cc7735">
<img width="300" alt="image" src="https://github.com/tyba-co/document_selfie_verification/assets/175073213/f94127c2-2413-4c5a-9313-fe8970afb3ca">





